### PR TITLE
feat: Implement DataSource processor

### DIFF
--- a/backend/__tests__/CodeReviewInsight.Application.Tests/Fixtures/TenantFixture.cs
+++ b/backend/__tests__/CodeReviewInsight.Application.Tests/Fixtures/TenantFixture.cs
@@ -14,7 +14,16 @@ public static class TenantFixture
             new TenantBuilder()
                 .WithId(Guid.NewGuid())
                 .WithName(_faker.Company.CompanyName())
-                .WithDataSource(new AutoFaker<AzureDevOps>().Generate(2))
+                .WithDataSource(BuildAzureDataSource(2))
                 .Build())
             .ToList();
+
+    public static DataSource BuildAzureDataSource() => BuildAzureDataSource(1)[0];
+
+    public static List<DataSource> BuildAzureDataSource(int qtd)
+    {
+        var list = new List<DataSource>(qtd);
+        list.AddRange(Enumerable.Range(0, qtd).Select(_ => new AutoFaker<AzureDevOps>().Generate()));
+        return list;
+    }
 }

--- a/backend/__tests__/CodeReviewInsight.Application.Tests/Services/Processors/DataSourceProcessorTest.cs
+++ b/backend/__tests__/CodeReviewInsight.Application.Tests/Services/Processors/DataSourceProcessorTest.cs
@@ -1,4 +1,7 @@
-using CodeReviewInsight.Application.Repositories;
+using CodeReviewInsight.Application.Services.Crawlers;
+using CodeReviewInsight.Application.Services.Processors.Impl;
+using CodeReviewInsight.Domain.Features.Configurations;
+using CodeReviewInsight.Domain.Features.Configurations.Entities;
 
 namespace CodeReviewInsight.Application.Tests.Services.Processors;
 
@@ -6,19 +9,30 @@ public class DataSourceProcessorTest
 {
     public DataSourceProcessorTest()
     {
-        PersonRepository = Substitute.For<IPersonRepository>();
+        CrawlerFactory = Substitute.For<ICrawlerFactory>();
+        Crawler = Substitute.For<IDataSourceCrawler>();
     }
 
-    internal IPersonRepository PersonRepository { get; }
+    internal ICrawlerFactory CrawlerFactory { get; }
+    internal IDataSourceCrawler Crawler { get; }
 
     [Fact]
-    public void Should_ExtractUsersFromDataSource()
+    public async Task Should_ExtractRepositoriesFromDataSourceAsync()
     {
         // Given
+        var tenant = TenantFixture.Build();
+        CrawlerFactory
+            .Create(Arg.Any<TenantId>(), Arg.Any<DataSource>())
+            .Returns(Crawler);
+        var processor = Build();
 
         // When
+        await processor.ProcessAsync(tenant);
 
         // Then
-        Assert.True(true);
+        CrawlerFactory.Received(tenant.DataSource.Count()).Create(tenant.Id, Arg.Any<DataSource>());
+        await Crawler.Received(tenant.DataSource.Count()).CrawAsync();
     }
+
+    private DataSourceProcessor Build() => new(CrawlerFactory);
 }

--- a/backend/__tests__/CodeReviewInsight.Application.Tests/Services/Processors/TenantProcessorTest.cs
+++ b/backend/__tests__/CodeReviewInsight.Application.Tests/Services/Processors/TenantProcessorTest.cs
@@ -25,7 +25,7 @@ public class TenantProcessorTest
             .GetAllAsync()
             .Returns(tenants);
         DataSourceProcessor
-            .ProcessAsync(Arg.Any<IEnumerable<DataSource>>())
+            .ProcessAsync(Arg.Any<Tenant>())
             .Returns(Task.CompletedTask);
 
         var processor = BuildTenantProcessor();
@@ -35,7 +35,7 @@ public class TenantProcessorTest
 
         // Then
         await TenantRepository.Received(1).GetAllAsync();
-        await DataSourceProcessor.Received(totalDataSources).ProcessAsync(Arg.Any<IEnumerable<DataSource>>());
+        await DataSourceProcessor.Received(totalDataSources).ProcessAsync(Arg.Any<Tenant>());
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class TenantProcessorTest
         // Given
         var tenant = TenantFixture.Build();
         DataSourceProcessor
-            .ProcessAsync(Arg.Any<IEnumerable<DataSource>>())
+            .ProcessAsync(Arg.Any<Tenant>())
             .Returns(Task.CompletedTask);
 
         var processor = BuildTenantProcessor();
@@ -54,7 +54,7 @@ public class TenantProcessorTest
 
         // Then
         await TenantRepository.DidNotReceive().GetAllAsync();
-        await DataSourceProcessor.Received(1).ProcessAsync(Arg.Any<IEnumerable<DataSource>>());
+        await DataSourceProcessor.Received(1).ProcessAsync(Arg.Any<Tenant>());
     }
 
     private TenantProcessor BuildTenantProcessor() => new(

--- a/backend/src/CodeReviewInsight.Application/Extensions/ApplicationExtensions.cs
+++ b/backend/src/CodeReviewInsight.Application/Extensions/ApplicationExtensions.cs
@@ -1,14 +1,18 @@
 using CodeReviewInsight.Application.Services;
 using CodeReviewInsight.Application.Services.Crawlers;
 using CodeReviewInsight.Application.Services.Crawlers.Impl;
+using CodeReviewInsight.Application.Services.Processors;
+using CodeReviewInsight.Application.Services.Processors.Impl;
 using CodeReviewInsight.Application.Services.Teams;
 using CodeReviewInsight.Application.Services.Teams.Impl;
 using CodeReviewInsight.Application.TenantFeature.Services;
 using CodeReviewInsight.Application.TenantFeature.Services.Impl;
 using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CodeReviewInsight.Application.Extensions;
 
+[ExcludeFromCodeCoverage]
 public static class ApplicationExtensions
 {
     public static IServiceCollection AddApplication(this IServiceCollection services) =>
@@ -17,5 +21,7 @@ public static class ApplicationExtensions
             .AddScoped<ICreateTeam, CreateTeam>()
             .AddScoped<IWorkItemsCrawler, WorkItemsCrawler>()
             .AddScoped<ITenantAdd, TenantAdd>()
-            .AddScoped<ITenantUpdate, TenantUpdate>();
+            .AddScoped<ITenantUpdate, TenantUpdate>()
+            .AddScoped<TenantProcessor>()
+            .AddScoped<IDataSourceProcessor, DataSourceProcessor>();
 }

--- a/backend/src/CodeReviewInsight.Application/Repositories/IGitRepositoryRepository.cs
+++ b/backend/src/CodeReviewInsight.Application/Repositories/IGitRepositoryRepository.cs
@@ -1,0 +1,8 @@
+using CodeReviewInsight.Domain.Features.GitRepositories;
+
+namespace CodeReviewInsight.Application.Repositories;
+
+public interface IGitRepositoryRepository
+{
+    Task BulkUpsertAsync(IEnumerable<GitRepository> extractedRepositories);
+}

--- a/backend/src/CodeReviewInsight.Application/Services/Crawlers/ICrawlerFactory.cs
+++ b/backend/src/CodeReviewInsight.Application/Services/Crawlers/ICrawlerFactory.cs
@@ -1,0 +1,9 @@
+using CodeReviewInsight.Domain.Features.Configurations;
+using CodeReviewInsight.Domain.Features.Configurations.Entities;
+
+namespace CodeReviewInsight.Application.Services.Crawlers;
+
+public interface ICrawlerFactory
+{
+    public IDataSourceCrawler Create(TenantId tenantId, DataSource dataSource);
+}

--- a/backend/src/CodeReviewInsight.Application/Services/Crawlers/IDataSourceCrawler.cs
+++ b/backend/src/CodeReviewInsight.Application/Services/Crawlers/IDataSourceCrawler.cs
@@ -1,0 +1,6 @@
+namespace CodeReviewInsight.Application.Services.Crawlers;
+
+public interface IDataSourceCrawler
+{
+    public Task CrawAsync();
+}

--- a/backend/src/CodeReviewInsight.Application/Services/Crawlers/IGitRepositoryCrawler.cs
+++ b/backend/src/CodeReviewInsight.Application/Services/Crawlers/IGitRepositoryCrawler.cs
@@ -1,0 +1,9 @@
+using CodeReviewInsight.Domain.Features.Configurations.Entities;
+using CodeReviewInsight.Domain.Features.GitRepositories;
+
+namespace CodeReviewInsight.Application.Services.Crawlers;
+
+public interface IGitRepositoryCrawler
+{
+    Task<IEnumerable<GitRepository>> GetRepositoriesFromAsync(IEnumerable<DataSource> enumerable);
+}

--- a/backend/src/CodeReviewInsight.Application/Services/Processors/IDataSourceProcessor.cs
+++ b/backend/src/CodeReviewInsight.Application/Services/Processors/IDataSourceProcessor.cs
@@ -4,5 +4,5 @@ namespace CodeReviewInsight.Application.Services.Processors;
 
 public interface IDataSourceProcessor
 {
-    Task ProcessAsync(IEnumerable<DataSource> dataSource);
+    Task ProcessAsync(Tenant tenant);
 }

--- a/backend/src/CodeReviewInsight.Application/Services/Processors/Impl/DataSourceProcessor.cs
+++ b/backend/src/CodeReviewInsight.Application/Services/Processors/Impl/DataSourceProcessor.cs
@@ -1,11 +1,19 @@
+using CodeReviewInsight.Application.Services.Crawlers;
 using CodeReviewInsight.Domain.Features.Configurations.Entities;
 
 namespace CodeReviewInsight.Application.Services.Processors.Impl;
 
-public class DataSourceProcessor : IDataSourceProcessor
+public class DataSourceProcessor(ICrawlerFactory crawlerFactory) : IDataSourceProcessor
 {
-    public Task ProcessAsync(IEnumerable<DataSource> dataSource)
+    private readonly ICrawlerFactory _crawlerFactory = crawlerFactory;
+
+    public async Task ProcessAsync(Tenant tenant)
     {
-        throw new NotImplementedException();
+        foreach (var dataSource in tenant.DataSource)
+        {
+            var crawler = _crawlerFactory.Create(tenant.Id, dataSource);
+
+            await crawler.CrawAsync();
+        }
     }
 }

--- a/backend/src/CodeReviewInsight.Application/Services/Processors/TenantProcessor.cs
+++ b/backend/src/CodeReviewInsight.Application/Services/Processors/TenantProcessor.cs
@@ -21,6 +21,6 @@ public class TenantProcessor(
 
     public async Task ProcessTenantAsync(Tenant tenant)
     {
-        await _dataSourceProcessor.ProcessAsync(tenant.DataSource);
+        await _dataSourceProcessor.ProcessAsync(tenant);
     }
 }


### PR DESCRIPTION
- Refact Tenant Processor to also send Tenant to DataSource processor.
- DataSourceProcessor Takes the decision about what is the Processor type to run. Then a DataSourceCrawler will be in charge of load data from data source and persist it.